### PR TITLE
Added customization and stop show touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,41 @@ pod 'ShowTouches', :configurations => ['Debug']
 
 ## How to set it up
 
-Just call `UIWindow.startShowingTouches()` anywhere in your app. (Also works with SwiftUI using [App](https://developer.apple.com/documentation/swiftui/app) and [WindowGroup](https://developer.apple.com/documentation/swiftui/windowgroup) added in Xcode 12.0)
+Just call `UIWindow.showTouches()` or `UIWindow.showTouches(false)` anywhere in your app to enable or disable showing touches. (Also works with SwiftUI using [App](https://developer.apple.com/documentation/swiftui/app) and [WindowGroup](https://developer.apple.com/documentation/swiftui/windowgroup) added in Xcode 12.0)
 
 And that's it!
 
+### Customization
+
+You may want to customize how touches are shown. Just call `UIWindow.configure()` passing a `ShowTouchesConfig` to override defaults. 
+
+⚠️ This must be done before the first call to `UIWindow.showTouches()`. ⚠️
+
+E.g.
+
+```swift
+let config = ShowTouchesConfig(touchColor: .green)
+UIWindow.configure(config)
+// [...]
+UIWindow.showTouches()
+``` 
+
 ### App Extensions
 
-If you are using App Extensions (such as Action extension or Keyboard extension), you can also show touches in them. Calling `UIWindow.startShowingTouches()` should work for those too.
+If you are using App Extensions (such as Action extension or Keyboard extension), you can also show touches in them. Calling `UIWindow.showTouches()` should work for those too.
 
 ### Only showing for specific views
 
-If you only want to display touches for specific views (or the other method doesn't work for you), a gesture recognizer is also available: `view.addGestureRecognizer(ShowTouchesGestureRecognizer())`
+If you only want to display touches for specific views (or the other method doesn't work for you), a gesture recognizer is also available: `view.addGestureRecognizer(ShowTouchesGestureRecognizer())`. 
+
+This can also be customized passing a `ShowTouchesConfig`.
+
+E.g.
+
+```swift
+let config = ShowTouchesConfig(touchColor: .green)
+view.addGestureRecognizer(ShowTouchesGestureRecognizer(config))
+``` 
 
 ## How it actually works
 

--- a/Sources/ShowTouches/ShowTouchesController.swift
+++ b/Sources/ShowTouches/ShowTouchesController.swift
@@ -1,18 +1,36 @@
 import UIKit
 
-struct Constants {
-	static let TouchColor = UIColor(red: 0.0 / 255, green: 135.0 / 255, blue: 244.0 / 255, alpha: 0.8)
-	static let CircleSize: CGFloat = 61.0
-	static let ShortTapTresholdDuration = 0.11
-	static let ShortTapInitialCircleRadius: CGFloat = 22.0
-	static let ShortTapFinalCircleRadius: CGFloat = 57.0
+public struct ShowTouchesConfig {
+	let touchColor: UIColor
+	let circleSize: CGFloat
+	let shortTapTresholdDuration: Double
+	let shortTapInitialCircleRadius: CGFloat
+	let shortTapFinalCircleRadius: CGFloat
+	
+	public init(touchColor: UIColor = UIColor(red: 0.0 / 255, green: 135.0 / 255, blue: 244.0 / 255, alpha: 0.8),
+				circleSize: CGFloat = 61.0,
+				shortTapTresholdDuration: Double = 0.11,
+				shortTapInitialCircleRadius: CGFloat = 22.0,
+				shortTapFinalCircleRadius: CGFloat = 57.0) {
+		self.touchColor = touchColor
+		self.circleSize = circleSize
+		self.shortTapTresholdDuration = shortTapTresholdDuration
+		self.shortTapInitialCircleRadius = shortTapInitialCircleRadius
+		self.shortTapFinalCircleRadius = shortTapFinalCircleRadius
+	}
 }
 
 class ShowTouchesController {
-	let touchImageViewQueue = GSTouchImageViewQueue(touchesCount: 8)
+	let touchImageViewQueue: GSTouchImageViewQueue
 	var touchImgViewsDict = [String: UIView]()
 	var touchesStartDateDict = [String: NSDate]()
-
+	let config: ShowTouchesConfig
+	
+	init(config: ShowTouchesConfig) {
+		self.config = config
+		touchImageViewQueue = GSTouchImageViewQueue(touchesCount: 8, config: config)
+	}
+	
 	public func touchBegan(_ touch: UITouch, view: UIView) {
 		let touchImgView = touchImageViewQueue.popTouchImageView()
 		touchImgView.center = touch.location(in: view)
@@ -39,7 +57,7 @@ class ShowTouchesController {
 		let touchDuration = NSDate().timeIntervalSince(touchStartDate as Date)
 		touchesStartDateDict.removeValue(forKey: String(format: "%p", touch))
 
-		if touchDuration < Constants.ShortTapTresholdDuration {
+		if touchDuration < config.shortTapTresholdDuration {
 			showExpandingCircle(at: touch.location(in: view), in: view)
 		}
 
@@ -56,8 +74,8 @@ class ShowTouchesController {
 
 	func showExpandingCircle(at position: CGPoint, in view: UIView) {
 		let circleLayer = CAShapeLayer()
-		let initialRadius = Constants.ShortTapInitialCircleRadius
-		let finalRadius = Constants.ShortTapFinalCircleRadius
+		let initialRadius = config.shortTapInitialCircleRadius
+		let finalRadius = config.shortTapFinalCircleRadius
 		circleLayer.position = CGPoint(x: position.x - initialRadius, y: position.y - initialRadius)
 
 		let startPathRect = CGRect(x: 0, y: 0, width: initialRadius * 2, height: initialRadius * 2)
@@ -69,7 +87,7 @@ class ShowTouchesController {
 
 		circleLayer.path = startPath.cgPath
 		circleLayer.fillColor = UIColor.clear.cgColor
-		circleLayer.strokeColor = Constants.TouchColor.cgColor
+		circleLayer.strokeColor = config.touchColor.cgColor
 		circleLayer.lineWidth = 2.0
 		view.layer.addSublayer(circleLayer)
 
@@ -118,13 +136,13 @@ class ShowTouchesController {
 class GSTouchImageViewQueue {
 	var backingArray = [UIView]()
 
-	convenience init(touchesCount: Int) {
+	convenience init(touchesCount: Int, config: ShowTouchesConfig) {
 		self.init()
 
 		for _ in 0 ..< touchesCount {
-			let imageView = UIView(frame: CGRect(x: 0, y: 0, width: Constants.CircleSize, height: Constants.CircleSize))
-			imageView.backgroundColor = Constants.TouchColor
-			imageView.layer.cornerRadius = Constants.CircleSize / 2
+			let imageView = UIView(frame: CGRect(x: 0, y: 0, width: config.circleSize, height: config.circleSize))
+			imageView.backgroundColor = config.touchColor
+			imageView.layer.cornerRadius = config.circleSize / 2
 			backingArray.append(imageView)
 		}
 	}

--- a/Sources/ShowTouches/ShowTouchesGestureRecognizer.swift
+++ b/Sources/ShowTouches/ShowTouchesGestureRecognizer.swift
@@ -1,9 +1,10 @@
 import UIKit
 
 public class ShowTouchesGestureRecognizer: UIGestureRecognizer, UIGestureRecognizerDelegate {
-	let touchesShowingController = ShowTouchesController()
-
-	public init() {
+	let touchesShowingController: ShowTouchesController
+	
+	public init(config: ShowTouchesConfig = ShowTouchesConfig()) {
+		touchesShowingController = ShowTouchesController(config: config)
 		super.init(target: nil, action: nil)
 		cancelsTouchesInView = false
 		delaysTouchesBegan = false

--- a/Sources/ShowTouches/UIWindow+ShowTouches.swift
+++ b/Sources/ShowTouches/UIWindow+ShowTouches.swift
@@ -38,20 +38,19 @@ extension UIWindow {
 	public static func configure(_ config: ShowTouchesConfig) {
 		Self.config = config
 	}
-	
+
+	static var isShowingTouches = false
 	@objc public static func showTouches(_ show: Bool = true) {
-		guard let originalMethod = class_getInstanceMethod(UIWindow.self, #selector(sendEvent(_:))),
-		      let newMethod = class_getInstanceMethod(UIWindow.self, #selector(showTouches_sendEvent(_:)))
+		guard isShowingTouches != show,
+			  let originalMethod = class_getInstanceMethod(UIWindow.self, #selector(sendEvent(_:))),
+			  let newMethod = class_getInstanceMethod(UIWindow.self, #selector(showTouches_sendEvent(_:)))
 		else {
 			return
 		}
-		
-		if show {
-			method_exchangeImplementations(originalMethod, newMethod)
-		} else {
-			method_exchangeImplementations(newMethod, originalMethod)
-		}
-	}	
+
+		isShowingTouches = !isShowingTouches
+		method_exchangeImplementations(originalMethod, newMethod)
+	}
 
 	@available(*, deprecated, message: "Use 'showTouches()' instead.")
 	@objc public static func startShowingTouches() {

--- a/Sources/ShowTouches/UIWindow+ShowTouches.swift
+++ b/Sources/ShowTouches/UIWindow+ShowTouches.swift
@@ -3,10 +3,12 @@ import UIKit
 
 extension UIWindow {
 	static var touchesShowingControllerKey = 0
+	private static var config: ShowTouchesConfig = ShowTouchesConfig()
+	
 	var controller: ShowTouchesController {
 		var controller: ShowTouchesController? = objc_getAssociatedObject(self, &UIWindow.touchesShowingControllerKey) as? ShowTouchesController
 		if controller == nil {
-			controller = ShowTouchesController()
+			controller = ShowTouchesController(config: Self.config)
 			objc_setAssociatedObject(self, &UIWindow.touchesShowingControllerKey, controller, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 		}
 		return controller!
@@ -32,17 +34,27 @@ extension UIWindow {
 			}
 		}
 	}
-
-	static var didStart = false
-	@objc public static func startShowingTouches() {
-		guard !didStart else { return }
-		didStart = true
-
+	
+	public static func configure(_ config: ShowTouchesConfig) {
+		Self.config = config
+	}
+	
+	@objc public static func showTouches(_ show: Bool = true) {
 		guard let originalMethod = class_getInstanceMethod(UIWindow.self, #selector(sendEvent(_:))),
 		      let newMethod = class_getInstanceMethod(UIWindow.self, #selector(showTouches_sendEvent(_:)))
 		else {
 			return
 		}
-		method_exchangeImplementations(originalMethod, newMethod)
+		
+		if show {
+			method_exchangeImplementations(originalMethod, newMethod)
+		} else {
+			method_exchangeImplementations(newMethod, originalMethod)
+		}
+	}	
+
+	@available(*, deprecated, message: "Use 'showTouches()' instead.")
+	@objc public static func startShowingTouches() {
+		showTouches()
 	}
 }


### PR DESCRIPTION
Added some customization options via `ShowTouchesConfig` and the possibility to turn off showing touches again. 

Kept but deprecated `startShowingTouches` method, in order to avoid breaking changes. In general everything should be backwards compatible, so that updating should not break anything.